### PR TITLE
Some fixes

### DIFF
--- a/client.rkt
+++ b/client.rkt
@@ -350,4 +350,4 @@
    (hash-ref json 'refresh_token #f)
    (hash-ref json 'audience #f)
    (string-split (hash-ref json 'scope empty-string) ",")
-   (+ (current-seconds) (hash-ref json 'expires_in "0"))))
+   (+ (current-seconds) (string->number (hash-ref json 'expires_in "0")))))

--- a/client.rkt
+++ b/client.rkt
@@ -236,10 +236,13 @@
 
 (define (token-request-common client data-list)
   (define headers
-    (if (false? (client-secret client))
-        '()
-        ;; RFC6749 §2.3
-        (list (make-auth-header (string-trim (bytes->string/latin-1 (encode-client client)))))))
+    (cons
+      (make-header-string 'accept "application/json")
+      (if (false? (client-secret client))
+          '()
+          ;; RFC6749 §2.3
+          (list (make-auth-header (string-trim (bytes->string/latin-1 (encode-client client)))))))
+  )
   (define response
     (do-post/form-encoded-list/json
      (string->url (client-token-uri client))

--- a/scribblings/oauth2.scrbl
+++ b/scribblings/oauth2.scrbl
@@ -48,7 +48,7 @@ A display string formatting the version of OAuth supported by the package.
               @defform*[((log-oauth2-fatal string-expr)
                          (log-oauth2-fatal format-string-expr v ...))])]{
 The logger instance, and logging procedures, used internally by the package. This is
-provided for tools to be ablt to log OAuth specific interactions with the same topic,
+provided for tools to be able to log OAuth specific interactions with the same topic,
 but also to adjust the level of logging performed by the library.
 }
 

--- a/storage/tokens.rkt
+++ b/storage/tokens.rkt
@@ -53,17 +53,23 @@
     [else #f]))
 
 (define (set-token! user-name service-name a-token)
-  (log-oauth2-debug "set-token! for ~a (~a), ~a" 
+  (log-oauth2-debug "set-token! for ~a (~a), ~a ~a"
                     user-name
                     (string? user-name)
-                    service-name)
+                    service-name
+                    (token-refresh-token a-token)
+                    )
   (define key (cons user-name service-name))
   (hash-set! tokens-cache
              key
              (struct-copy token
                           a-token
                           [access-token (encrypt-secret (token-access-token a-token))]
-                          [refresh-token (encrypt-secret (token-refresh-token a-token))])))
+                          [refresh-token
+                            (if (token-refresh-token a-token)
+                                (encrypt-secret (token-refresh-token a-token))
+                                #f)
+                                ])))
 
 ;; ---------- Startup procedures
 


### PR DESCRIPTION
- The application/json Accept header should probably be set to receive the correct body from the provider (fixes Github sending the correct content)
- `expires_in` might not be set and has to be cast into a number
- in my case the `refresh_token` from github is #f and it failed encrypting